### PR TITLE
Migrate to CloudFunctions v1 API.

### DIFF
--- a/info/lib/displayServiceInfo.js
+++ b/info/lib/displayServiceInfo.js
@@ -37,7 +37,7 @@ module.exports = {
     };
 
     _.forEach(resources.resources, (resource) => {
-      if (resource.type === 'cloudfunctions.v1beta2.function') {
+      if (resource.type === 'gcp-types/cloudfunctions-v1:projects.locations.functions') {
         const serviceFuncName = getFunctionNameInService(
           resource.name, this.serverless.service.service, this.options.stage);
         const serviceFunc = this.serverless.service.getFunction(serviceFuncName);
@@ -50,7 +50,7 @@ module.exports = {
           const region = this.options.region;
           const project = this.serverless.service.provider.project;
           const baseUrl = `https://${region}-${project}.cloudfunctions.net`;
-          const path = serviceFunc.handler; // NOTE this might change
+          const path = serviceFunc.name; // NOTE this might change
           funcResource = `${baseUrl}/${path}`;
         }
 

--- a/info/lib/displayServiceInfo.test.js
+++ b/info/lib/displayServiceInfo.test.js
@@ -103,8 +103,8 @@ describe('DisplayServiceInfo', () => {
       const resources = {
         resources: [
           { type: 'resource.which.should.be.filterered', name: 'someResource' },
-          { type: 'cloudfunctions.v1beta2.function', name: 'my-service-dev-func1' },
-          { type: 'cloudfunctions.v1beta2.function', name: 'my-service-dev-func2' },
+          { type: 'gcp-types/cloudfunctions-v1:projects.locations.functions', name: 'my-service-dev-func1' },
+          { type: 'gcp-types/cloudfunctions-v1:projects.locations.functions', name: 'my-service-dev-func2' },
         ],
       };
 
@@ -117,7 +117,7 @@ describe('DisplayServiceInfo', () => {
           functions: [
             {
               name: 'func1',
-              resource: 'https://us-central1-my-project.cloudfunctions.net/handler',
+              resource: 'https://us-central1-my-project.cloudfunctions.net/my-service-dev-func1',
             },
             {
               name: 'func2',
@@ -176,7 +176,7 @@ describe('DisplayServiceInfo', () => {
           functions: [
             {
               name: 'func1',
-              resource: 'https://us-central1-my-project.cloudfunctions.net/handler',
+              resource: 'https://us-central1-my-project.cloudfunctions.net/my-service-dev-func1',
             },
             {
               name: 'func2',
@@ -197,7 +197,7 @@ describe('DisplayServiceInfo', () => {
 
       expectedOutput += `${chalk.yellow.underline('Deployed functions')}\n`;
       expectedOutput += `${chalk.yellow('func1')}\n`;
-      expectedOutput += '  https://us-central1-my-project.cloudfunctions.net/handler\n';
+      expectedOutput += '  https://us-central1-my-project.cloudfunctions.net/my-service-dev-func1\n';
       expectedOutput += `${chalk.yellow('func2')}\n`;
       expectedOutput += '  projects/*/topics/my-test-topic\n';
 

--- a/package/lib/compileFunctions.test.js
+++ b/package/lib/compileFunctions.test.js
@@ -23,11 +23,12 @@ describe('CompileFunctions', () => {
         resources: [],
       },
       deploymentBucketName: 'sls-my-service-dev-12345678',
+      project: 'myProject',
+      region: 'us-central1',
     };
     serverless.setProvider('google', new GoogleProvider(serverless));
     const options = {
       stage: 'dev',
-      region: 'us-central1',
     };
     googlePackage = new GooglePackage(serverless, options);
     consoleLogStub = sinon.stub(googlePackage.serverless.cli, 'log').returns();
@@ -110,12 +111,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -145,12 +147,13 @@ describe('CompileFunctions', () => {
       googlePackage.serverless.service.provider.memorySize = 1024;
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 1024,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -180,12 +183,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -215,12 +219,13 @@ describe('CompileFunctions', () => {
       googlePackage.serverless.service.provider.timeout = '120s';
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '120s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -252,12 +257,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -291,12 +297,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -334,12 +341,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -374,12 +382,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           environmentVariables: {
             TEST_VAR: 'test',
@@ -414,12 +423,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           environmentVariables: {
             TEST_VAR: 'test',
@@ -451,12 +461,13 @@ describe('CompileFunctions', () => {
       };
 
       const compiledResources = [{
-        type: 'cloudfunctions.v1beta2.function',
+        type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
         name: 'my-service-dev-func1',
         properties: {
-          location: 'us-central1',
+          parent: 'projects/myProject/locations/us-central1',
           runtime: 'nodejs8',
-          function: 'func1',
+          function: 'my-service-dev-func1',
+          entryPoint: 'func1',
           availableMemoryMb: 256,
           timeout: '60s',
           sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -503,12 +514,13 @@ describe('CompileFunctions', () => {
 
       const compiledResources = [
         {
-          type: 'cloudfunctions.v1beta2.function',
+          type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
           name: 'my-service-dev-func1',
           properties: {
-            location: 'us-central1',
+            parent: 'projects/myProject/locations/us-central1',
             runtime: 'nodejs8',
-            function: 'func1',
+            function: 'my-service-dev-func1',
+            entryPoint: 'func1',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',
@@ -521,12 +533,13 @@ describe('CompileFunctions', () => {
           },
         },
         {
-          type: 'cloudfunctions.v1beta2.function',
+          type: 'gcp-types/cloudfunctions-v1:projects.locations.functions',
           name: 'my-service-dev-func2',
           properties: {
-            location: 'us-central1',
+            parent: 'projects/myProject/locations/us-central1',
             runtime: 'nodejs8',
-            function: 'func2',
+            function: 'my-service-dev-func2',
+            entryPoint: 'func2',
             availableMemoryMb: 256,
             timeout: '60s',
             sourceArchiveUrl: 'gs://sls-my-service-dev-12345678/some-path/artifact.zip',


### PR DESCRIPTION
- 'location' property migrate to 'parent'.
- Use 'entryPoint' property to specify handler function.
- Use 'function' property for stage-distinct function name.